### PR TITLE
[FEAT] 게시글 좋아요, 댓글 기능 시 게시글 통계 테이블 댓글 수, 좋아요 수 업데이트 토픽 메세지 발송 기능 추가

### DIFF
--- a/src/main/java/hobbiedo/board/application/BoardInteractionServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/BoardInteractionServiceImpl.java
@@ -20,6 +20,9 @@ import hobbiedo.board.dto.response.LikeStatusDto;
 import hobbiedo.board.infrastructure.BoardRepository;
 import hobbiedo.board.infrastructure.CommentRepository;
 import hobbiedo.board.infrastructure.LikesRepository;
+import hobbiedo.board.kafka.application.KafkaProducerService;
+import hobbiedo.board.kafka.dto.BoardCommentUpdateDto;
+import hobbiedo.board.kafka.dto.BoardLikeUpdateDto;
 import hobbiedo.global.api.exception.handler.BoardExceptionHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +36,9 @@ public class BoardInteractionServiceImpl implements BoardInteractionService {
 	private final CommentRepository commentRepository;
 	private final BoardRepository boardRepository;
 	private final LikesRepository likesRepository;
+
+	// kafka producer service 추가
+	private final KafkaProducerService kafkaProducerService;
 
 	/**
 	 * 댓글 생성
@@ -70,6 +76,13 @@ public class BoardInteractionServiceImpl implements BoardInteractionService {
 			.build();
 
 		commentRepository.save(comment);
+
+		// 댓글 생성 시 통계 테이블에 댓글 수 증가 이벤트 메시지 전송
+		BoardCommentUpdateDto eventDto = BoardCommentUpdateDto.builder()
+			.boardId(boardId)
+			.build();
+
+		kafkaProducerService.sendUpdateCommentCountMessage(eventDto);
 	}
 
 	/**
@@ -125,6 +138,13 @@ public class BoardInteractionServiceImpl implements BoardInteractionService {
 		}
 
 		commentRepository.deleteById(commentId);
+
+		// 댓글 삭제 시 통계 테이블에 댓글 수 감소 이벤트 메시지 전송
+		BoardCommentUpdateDto eventDto = BoardCommentUpdateDto.builder()
+			.boardId(comment.getBoard().getId())
+			.build();
+
+		kafkaProducerService.sendDeleteCommentCountMessage(eventDto);
 	}
 
 	/**
@@ -152,6 +172,13 @@ public class BoardInteractionServiceImpl implements BoardInteractionService {
 			.build();
 
 		likesRepository.save(likes);
+
+		// 좋아요 생성 시 통계 테이블에 좋아요 수 증가 이벤트 메시지 전송
+		BoardLikeUpdateDto eventDto = BoardLikeUpdateDto.builder()
+			.boardId(boardId)
+			.build();
+
+		kafkaProducerService.sendUpdateLikeCountMessage(eventDto);
 	}
 
 	/**
@@ -195,6 +222,13 @@ public class BoardInteractionServiceImpl implements BoardInteractionService {
 			.orElseThrow(() -> new BoardExceptionHandler(DELETE_LIKE_NOT_EXIST));
 
 		likesRepository.delete(likes);
+
+		// 좋아요 삭제 시 통계 테이블에 좋아요 수 감소 이벤트 메시지 전송
+		BoardLikeUpdateDto eventDto = BoardLikeUpdateDto.builder()
+			.boardId(boardId)
+			.build();
+
+		kafkaProducerService.sendDeleteLikeCountMessage(eventDto);
 	}
 
 	/**

--- a/src/main/java/hobbiedo/board/application/BoardInteractionServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/BoardInteractionServiceImpl.java
@@ -103,8 +103,7 @@ public class BoardInteractionServiceImpl implements BoardInteractionService {
 
 		// 댓글 리스트가 비어있어도 예외 처리하지 않음
 		List<CommentResponseDto> commentResponseDtoList = comments.stream()
-			.sorted(Comparator.comparing(Comment::getCreatedAt)
-				.reversed()) // 최신순 정렬
+			.sorted(Comparator.comparing(Comment::getCreatedAt))
 			.map(comment -> CommentResponseDto.builder()
 				.commentId(comment.getId())
 				.writerUuid(comment.getWriterUuid())

--- a/src/main/java/hobbiedo/board/application/BoardServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/BoardServiceImpl.java
@@ -4,6 +4,7 @@ import static hobbiedo.global.api.code.status.ErrorStatus.*;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 
 import org.springframework.data.domain.Page;
@@ -233,13 +234,14 @@ public class BoardServiceImpl implements BoardService {
 	public BoardResponseDto getPinnedPost(Long crewId) {
 
 		// 소모임에 속한 고정된 게시글 조회
-		Board board = boardRepository.findByIsPinnedTrueAndCrewId(crewId)
-			.orElse(null);
+		Optional<Board> optionalBoard = boardRepository.findByIsPinnedTrueAndCrewId(crewId);
 
 		// 고정된 게시글이 없을 경우 null 반환
-		if (board == null) {
+		if (!optionalBoard.isPresent()) {
 			return null;
 		}
+
+		Board board = optionalBoard.get();
 
 		return BoardResponseDto.builder()
 			.boardId(board.getId())

--- a/src/main/java/hobbiedo/board/application/BoardServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/BoardServiceImpl.java
@@ -78,7 +78,10 @@ public class BoardServiceImpl implements BoardService {
 		}
 
 		// kafka 메세지 전송
-		BoardCreateEventDto eventDto = new BoardCreateEventDto(createdBoard.getId());
+		BoardCreateEventDto eventDto = BoardCreateEventDto.builder()
+			.boardId(createdBoard.getId())
+			.build();
+
 		kafkaProducerService.sendCreateTableMessage(eventDto);
 	}
 
@@ -214,7 +217,10 @@ public class BoardServiceImpl implements BoardService {
 		boardRepository.deleteById(boardId);
 
 		// kafka 메세지 전송
-		BoardDeleteEventDto eventDto = new BoardDeleteEventDto(boardId);
+		BoardDeleteEventDto eventDto = BoardDeleteEventDto.builder()
+			.boardId(boardId)
+			.build();
+
 		kafkaProducerService.sendDeleteTableMessage(eventDto);
 	}
 

--- a/src/main/java/hobbiedo/board/kafka/application/KafkaProducerService.java
+++ b/src/main/java/hobbiedo/board/kafka/application/KafkaProducerService.java
@@ -4,8 +4,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
+import hobbiedo.board.kafka.dto.BoardCommentUpdateDto;
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardLikeUpdateDto;
 
 @Service
 public class KafkaProducerService {
@@ -15,6 +17,18 @@ public class KafkaProducerService {
 
 	// 통계 테이블 삭제 이벤트용 토픽
 	private static final String BOARD_DELETE_TOPIC = "board-delete-topic";
+
+	// 통계 테이블 댓글 수 증가 이벤트용 토픽
+	private static final String BOARD_COMMENT_UPDATE_TOPIC = "board-comment-update-topic";
+
+	// 통계 테이블 댓글 수 감소 이벤트용 토픽
+	private static final String BOARD_COMMENT_DELETE_TOPIC = "board-comment-delete-topic";
+
+	// 통계 테이블 좋아요 수 증가 이벤트용 토픽
+	private static final String BOARD_LIKE_UPDATE_TOPIC = "board-like-update-topic";
+
+	// 통계 테이블 좋아요 수 감소 이벤트용 토픽
+	private static final String BOARD_LIKE_DELETE_TOPIC = "board-like-delete-topic";
 
 	@Autowired
 	private KafkaTemplate<String, Object> kafkaTemplate;
@@ -35,6 +49,50 @@ public class KafkaProducerService {
 		try {
 
 			kafkaTemplate.send(BOARD_DELETE_TOPIC, eventDto);
+		} catch (Exception e) {
+
+			e.printStackTrace();
+		}
+	}
+
+	// 게시글 댓글 수 업데이트 이벤트 메시지 전송
+	public void sendUpdateCommentCountMessage(BoardCommentUpdateDto eventDto) {
+		try {
+
+			kafkaTemplate.send(BOARD_COMMENT_UPDATE_TOPIC, eventDto);
+		} catch (Exception e) {
+
+			e.printStackTrace();
+		}
+	}
+
+	// 게시글 댓글 수 감소 이벤트 메시지 전송
+	public void sendDeleteCommentCountMessage(BoardCommentUpdateDto eventDto) {
+		try {
+
+			kafkaTemplate.send(BOARD_COMMENT_DELETE_TOPIC, eventDto);
+		} catch (Exception e) {
+
+			e.printStackTrace();
+		}
+	}
+
+	// 게시글 좋아요 수 업데이트 이벤트 메시지 전송
+	public void sendUpdateLikeCountMessage(BoardLikeUpdateDto eventDto) {
+		try {
+
+			kafkaTemplate.send(BOARD_LIKE_UPDATE_TOPIC, eventDto);
+		} catch (Exception e) {
+
+			e.printStackTrace();
+		}
+	}
+
+	// 게시글 좋아요 수 감소 이벤트 메시지 전송
+	public void sendDeleteLikeCountMessage(BoardLikeUpdateDto eventDto) {
+		try {
+
+			kafkaTemplate.send(BOARD_LIKE_DELETE_TOPIC, eventDto);
 		} catch (Exception e) {
 
 			e.printStackTrace();

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardCommentUpdateDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardCommentUpdateDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class BoardDeleteEventDto {
+public class BoardCommentUpdateDto {
 
 	private Long boardId;
 }

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardCreateEventDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardCreateEventDto.java
@@ -1,9 +1,11 @@
 package hobbiedo.board.kafka.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Builder
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardLikeUpdateDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardLikeUpdateDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class BoardDeleteEventDto {
+public class BoardLikeUpdateDto {
 
 	private Long boardId;
 }

--- a/src/main/java/hobbiedo/board/presentation/BoardController.java
+++ b/src/main/java/hobbiedo/board/presentation/BoardController.java
@@ -61,7 +61,7 @@ public class BoardController {
 	@Operation(summary = "게시글 목록 조회", description = "해당 소모임의 게시글 목록을 조회합니다.")
 	public ApiResponse<BoardListResponseVo> getPostList(
 		@PathVariable("crewId") Long crewId,
-		@PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable page) {
+		@PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable page) {
 
 		BoardListResponseDto boardListResponseDto = boardService.getPostList(crewId, page);
 

--- a/src/main/java/hobbiedo/board/presentation/BoardInteractionController.java
+++ b/src/main/java/hobbiedo/board/presentation/BoardInteractionController.java
@@ -58,7 +58,7 @@ public class BoardInteractionController {
 	@Operation(summary = "게시글 댓글 조회", description = "게시글에 등록된 댓글들을 조회합니다.")
 	public ApiResponse<CommentListResponseVo> getCommentList(
 		@PathVariable("boardId") Long boardId,
-		@PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable page) {
+		@PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable page) {
 
 		CommentListResponseDto commentListResponseDto = boardInteractionService.getCommentList(
 			boardId, page);

--- a/src/main/java/hobbiedo/global/config/KafkaProducerConfig.java
+++ b/src/main/java/hobbiedo/global/config/KafkaProducerConfig.java
@@ -31,7 +31,7 @@ public class KafkaProducerConfig {
 		configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
 		configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
 		configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-			JsonSerializer.class); // JsonSerializer for JSON
+			JsonSerializer.class); // JsonSerializer 사용함으로써 객체 JSON 으로 변환
 
 		return new DefaultKafkaProducerFactory<>(configProps);
 	}


### PR DESCRIPTION
## 📣 게시글 좋아요, 댓글 기능 시 게시글 통계 테이블 댓글 수, 좋아요 수 업데이트 토픽 메세지 발송 기능 추가
### 📅 날짜 -  2024.06.16

### 🌵Branch
feature/update-board-stats-and-message-dispatch  → develop

### 📢 Description
**사용자들이 게시글에 좋아요와 댓글 게시 및 삭제, 취소 시 이를 업데이트 하는 토픽을 메세지를 발송하는 로직을 추가**

### 💬Issue Number
[#11 ] - 💫[FEAT] 게시글 좋아요, 댓글 기능 시 게시글 통계 테이블 댓글 수, 좋아요 수 업데이트 토픽 메세지 발송 기능 추가 #11

### 🛠️Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
1. 댓글 개시, 삭제, 좋아요 추가, 취소까지 총 4개의 토픽을 생성하였고, 각 서비스 로직에 해당 토픽 메세지를 발송하는 로직 추가
2. 토픽은 4개이지만 컨슈머에서는 해당 토픽을 보고 그에 따라 업데이트만 하면 되므로, 보내는 Dto 는 해당 게시글 id 를 가지는댓글 업데이트, 좋아요 업데이트 Dto 총 2개만 생성하였다. 
3. 로컬에서 연결하여 Swagger 를 사용하여 테스트를 진행하였고, Offser Explorer 를 통해 토픽과 메세지가 발송되는 것을 확인하였다
4. 컨슈머인 배치 서비스에서 해당 토픽을 받으면 이를 스프링 배치로 관리하며 일정 시간마다 통계 테이블에 업데이트하는 로직 추가 예정이며 이 과정에서 보내는 데이터의 형식 변화가 필요해보이면 토픽 형식 수정 예정이다