### PR TITLE
[FEAT] 게시글 생성 삭제 시 소모임 팀 점수 업데이트 토픽 발송

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.apache.kafka:kafka-clients'
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'

--- a/src/main/java/hobbiedo/board/application/BoardServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/BoardServiceImpl.java
@@ -22,7 +22,9 @@ import hobbiedo.board.infrastructure.BoardImageRepository;
 import hobbiedo.board.infrastructure.BoardRepository;
 import hobbiedo.board.kafka.application.KafkaProducerService;
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
+import hobbiedo.board.kafka.dto.BoardCreateScoreDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardDeleteScoreDto;
 import hobbiedo.global.api.exception.handler.BoardExceptionHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -84,6 +86,13 @@ public class BoardServiceImpl implements BoardService {
 			.build();
 
 		kafkaProducerService.sendCreateTableMessage(eventDto);
+
+		// kafka 메세지 전송, 소모임 점수 증가
+		BoardCreateScoreDto scoreDto = BoardCreateScoreDto.builder()
+			.crewId(crewId)
+			.build();
+
+		kafkaProducerService.sendIncreaseCrewScoreMessage(scoreDto);
 	}
 
 	/**`
@@ -223,6 +232,13 @@ public class BoardServiceImpl implements BoardService {
 			.build();
 
 		kafkaProducerService.sendDeleteTableMessage(eventDto);
+
+		// kafka 메세지 전송, 소모임 점수 감소
+		BoardDeleteScoreDto scoreDto = BoardDeleteScoreDto.builder()
+			.crewId(board.getCrewId())
+			.build();
+
+		kafkaProducerService.sendDecreaseCrewScoreMessage(scoreDto);
 	}
 
 	/**

--- a/src/main/java/hobbiedo/board/kafka/application/KafkaProducerService.java
+++ b/src/main/java/hobbiedo/board/kafka/application/KafkaProducerService.java
@@ -6,7 +6,9 @@ import org.springframework.stereotype.Service;
 
 import hobbiedo.board.kafka.dto.BoardCommentUpdateDto;
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
+import hobbiedo.board.kafka.dto.BoardCreateScoreDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardDeleteScoreDto;
 import hobbiedo.board.kafka.dto.BoardLikeUpdateDto;
 
 @Service
@@ -29,6 +31,12 @@ public class KafkaProducerService {
 
 	// 통계 테이블 좋아요 수 감소 이벤트용 토픽
 	private static final String BOARD_LIKE_DELETE_TOPIC = "board-like-delete-topic";
+
+	// 게시글 생성 시 소모임 점수 증가 이벤트용 토픽
+	private static final String CREW_SCORE_INCREASE_TOPIC = "crew-score-increase-topic";
+
+	// 게시글 삭제 시 소모임 점수 감소 이벤트용 토픽
+	private static final String CREW_SCORE_DECREASE_TOPIC = "crew-score-decrease-topic";
 
 	@Autowired
 	private KafkaTemplate<String, Object> kafkaTemplate;
@@ -93,6 +101,28 @@ public class KafkaProducerService {
 		try {
 
 			kafkaTemplate.send(BOARD_LIKE_DELETE_TOPIC, eventDto);
+		} catch (Exception e) {
+
+			e.printStackTrace();
+		}
+	}
+
+	// 게시글 생성 시 소모임 점수 증가 이벤트 메시지 전송
+	public void sendIncreaseCrewScoreMessage(BoardCreateScoreDto eventDto) {
+		try {
+
+			kafkaTemplate.send(CREW_SCORE_INCREASE_TOPIC, eventDto);
+		} catch (Exception e) {
+
+			e.printStackTrace();
+		}
+	}
+
+	// 게시글 삭제 시 소모임 점수 감소 이벤트 메시지 전송
+	public void sendDecreaseCrewScoreMessage(BoardDeleteScoreDto eventDto) {
+		try {
+
+			kafkaTemplate.send(CREW_SCORE_DECREASE_TOPIC, eventDto);
 		} catch (Exception e) {
 
 			e.printStackTrace();

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardCreateScoreDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardCreateScoreDto.java
@@ -1,0 +1,15 @@
+package hobbiedo.board.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardCreateScoreDto {
+
+	private Long crewId;
+}

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardDeleteScoreDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardDeleteScoreDto.java
@@ -1,0 +1,15 @@
+package hobbiedo.board.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardDeleteScoreDto {
+
+	private Long crewId;
+}

--- a/src/main/java/hobbiedo/board/vo/response/BoardDetailsResponseVo.java
+++ b/src/main/java/hobbiedo/board/vo/response/BoardDetailsResponseVo.java
@@ -1,7 +1,6 @@
 package hobbiedo.board.vo.response;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import hobbiedo.board.dto.response.BoardDetailsResponseDto;
@@ -18,7 +17,7 @@ public class BoardDetailsResponseVo {
 	private String content;
 	private String writerUuid;
 	private boolean pinned; // 고정 여부
-	private String createdAt; // 작성일
+	private LocalDateTime createdAt; // 작성일
 	private boolean updated; // 수정 여부
 	private List<String> imageUrls;
 
@@ -28,11 +27,7 @@ public class BoardDetailsResponseVo {
 		this.content = content;
 		this.writerUuid = writerUuid;
 		this.pinned = pinned;
-
-		// 날짜, 시간 형식 지정
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy. MM. dd HH:mm");
-
-		this.createdAt = createdAt.format(formatter); // 작성일 (날짜, 시간 형식으로 변환)
+		this.createdAt = createdAt; // 작성일 (날짜, 시간 형식으로 변환)
 		this.updated = updated;
 		this.imageUrls = imageUrls;
 	}

--- a/src/main/java/hobbiedo/board/vo/response/CommentResponseVo.java
+++ b/src/main/java/hobbiedo/board/vo/response/CommentResponseVo.java
@@ -1,7 +1,6 @@
 package hobbiedo.board.vo.response;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import hobbiedo.board.dto.response.CommentResponseDto;
@@ -18,7 +17,7 @@ public class CommentResponseVo {
 	private String writerUuid; // 작성자 uuid
 	private String content; // 댓글 내용
 	private Boolean isInCrew; // 소모임 회원 여부
-	private String createdAt; // 작성일
+	private LocalDateTime createdAt; // 작성일
 
 	public CommentResponseVo(Long commentId, String writerUuid, String content, Boolean isInCrew,
 		LocalDateTime createdAt) {
@@ -26,11 +25,7 @@ public class CommentResponseVo {
 		this.writerUuid = writerUuid;
 		this.content = content;
 		this.isInCrew = isInCrew;
-
-		// 날짜, 시간 형식 지정
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy. MM. dd HH:mm");
-
-		this.createdAt = createdAt.format(formatter);
+		this.createdAt = createdAt;
 	}
 
 	public static List<CommentResponseVo> commentDtoToCommentListResponseVo(


### PR DESCRIPTION
## 📣게시글 생성 삭제 시 소모임 팀 점수 업데이트 토픽 발송
### 📅 날짜 -  2024.06.18

### 🌵Branch
feature/post-create-delete-notification  → develop

### 📢 Description
**1. 게시글 생성 시 소모임 점수 증가 이벤트용 토픽을 정의하고 생성이 되면 메세지가 발송한다.**
**2. 게시글 삭제 시 소모임 점수 감소 이벤트용 토픽을 정의하고 삭제가 되면 메세지가 발송한다.**

### 💬Issue Number
[#13 ] - 💫[FEAT] 게시글 생성 삭제 시 소모임 팀 점수 업데이트 토픽 발송 #13

### 🛠️Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
1. Consumer 인 소모임 서비스와 토픽과 주고 받을 데이터의 형태를 맞추고 토픽을 생성하였다
2. Swagger 와 Offset Explorer 를 통해 토픽이 발송되고 있는 것을 확인하였다