### PR TITLE
[REFACTOR] 게시글 댓글 생성 데이터 필드 수정 및 삭제 토픽용 데이터 Dto 추가

### DIFF
--- a/src/main/java/hobbiedo/board/application/BoardInteractionServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/BoardInteractionServiceImpl.java
@@ -21,6 +21,7 @@ import hobbiedo.board.infrastructure.BoardRepository;
 import hobbiedo.board.infrastructure.CommentRepository;
 import hobbiedo.board.infrastructure.LikesRepository;
 import hobbiedo.board.kafka.application.KafkaProducerService;
+import hobbiedo.board.kafka.dto.BoardCommentDeleteDto;
 import hobbiedo.board.kafka.dto.BoardCommentUpdateDto;
 import hobbiedo.board.kafka.dto.BoardLikeUpdateDto;
 import hobbiedo.board.kafka.dto.BoardPinEventDto;
@@ -82,6 +83,11 @@ public class BoardInteractionServiceImpl implements BoardInteractionService {
 		// 댓글 생성 시 통계 테이블에 댓글 수 증가 이벤트 메시지 전송
 		BoardCommentUpdateDto eventDto = BoardCommentUpdateDto.builder()
 			.boardId(boardId)
+			.commentId(comment.getId())
+			.writerUuid(uuid)
+			.content(commentUploadRequestDto.getContent())
+			.isInCrew(commentUploadRequestDto.getIsInCrew())
+			.createdAt(comment.getCreatedAt())
 			.build();
 
 		kafkaProducerService.sendUpdateCommentCountMessage(eventDto);
@@ -141,8 +147,9 @@ public class BoardInteractionServiceImpl implements BoardInteractionService {
 		commentRepository.deleteById(commentId);
 
 		// 댓글 삭제 시 통계 테이블에 댓글 수 감소 이벤트 메시지 전송
-		BoardCommentUpdateDto eventDto = BoardCommentUpdateDto.builder()
+		BoardCommentDeleteDto eventDto = BoardCommentDeleteDto.builder()
 			.boardId(comment.getBoard().getId())
+			.commentId(commentId)
 			.build();
 
 		kafkaProducerService.sendDeleteCommentCountMessage(eventDto);

--- a/src/main/java/hobbiedo/board/kafka/application/KafkaProducerService.java
+++ b/src/main/java/hobbiedo/board/kafka/application/KafkaProducerService.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
+import hobbiedo.board.kafka.dto.BoardCommentDeleteDto;
 import hobbiedo.board.kafka.dto.BoardCommentUpdateDto;
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
@@ -30,10 +31,10 @@ public class KafkaProducerService {
 	// 게시글 고정 해제 이벤트용 토픽
 	private static final String BOARD_UNPIN_TOPIC = "board-unpin-topic";
 
-	// 게시글 댓글 수 증가 이벤트용 토픽
+	// 게시글 댓글 작성 이벤트용 토픽
 	private static final String BOARD_COMMENT_UPDATE_TOPIC = "board-comment-update-topic";
 
-	// 게시글 댓글 수 감소 이벤트용 토픽
+	// 게시글 댓글 삭제 이벤트용 토픽
 	private static final String BOARD_COMMENT_DELETE_TOPIC = "board-comment-delete-topic";
 
 	// 게시글 좋아요 수 증가 이벤트용 토픽
@@ -100,7 +101,7 @@ public class KafkaProducerService {
 		}
 	}
 
-	// 게시글 댓글 수 업데이트 이벤트 메시지 전송
+	// 게시글 댓글 작성 이벤트 메시지 전송
 	public void sendUpdateCommentCountMessage(BoardCommentUpdateDto eventDto) {
 		try {
 
@@ -111,8 +112,8 @@ public class KafkaProducerService {
 		}
 	}
 
-	// 게시글 댓글 수 감소 이벤트 메시지 전송
-	public void sendDeleteCommentCountMessage(BoardCommentUpdateDto eventDto) {
+	// 게시글 댓글 삭제 이벤트 메시지 전송
+	public void sendDeleteCommentCountMessage(BoardCommentDeleteDto eventDto) {
 		try {
 
 			kafkaTemplate.send(BOARD_COMMENT_DELETE_TOPIC, eventDto);

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardCommentDeleteDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardCommentDeleteDto.java
@@ -1,0 +1,16 @@
+package hobbiedo.board.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardCommentDeleteDto {
+
+	private Long boardId;
+	private Long commentId;
+}

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardCommentUpdateDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardCommentUpdateDto.java
@@ -1,5 +1,7 @@
 package hobbiedo.board.kafka.dto;
 
+import java.time.LocalDateTime;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,5 +13,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class BoardCommentUpdateDto {
 
-	private Long boardId;
+	private Long boardId; // 게시글 번호
+	private Long commentId; // 댓글 번호
+	private String writerUuid; // 작성자 uuid
+	private String content; // 댓글 내용
+	private Boolean isInCrew; // 소모임 회원 여부
+	private LocalDateTime createdAt; // 작성일
 }


### PR DESCRIPTION
## 📣 게시글 댓글 생성 데이터 필드 수정 및 삭제 토픽용 데이터 Dto 추가
### 📅 날짜 -  2024.06.22

### 🌵Branch
feature/comment-create-delete-topic  → develop

### 📢 Description
**1. 읽기 전용 댓글 테이블 생성을 위한 데이터 필드 BoardCommentUpdateDto 수정**
**2. 읽기 전용 댓글 테이블 삭제를 위한 데이터 BoardCommentDeleteDto 파일 생성**

### 💬Issue Number
[#18 ] - ♻️[REFACTOR] 게시글 댓글 생성 데이터 필드 수정 및 삭제 토픽용 데이터 Dto 추가 #18

### 🛠️Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
1. Swagger 와 Offset Explorer 를 통해 토픽이 정상적으로 발송되는 것을  확인하였다