### PR TITLE
[REFACTOR] 게시글 댓글 작성 형식 및 저장 로직 수정

### DIFF
--- a/src/main/java/hobbiedo/board/application/BoardInteractionServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/BoardInteractionServiceImpl.java
@@ -56,15 +56,10 @@ public class BoardInteractionServiceImpl implements BoardInteractionService {
 
 		String content = commentUploadRequestDto.getContent();
 
-		Boolean isInCrew = commentUploadRequestDto.getIsInCrew();
-
 		// 댓글 내용이 비어있을 경우, isInCrew 가 비어있을 경우 예외 처리
 		if (content == null || content.trim().isEmpty()) {
 
 			throw new BoardExceptionHandler(CREATE_COMMENT_CONTENT_EMPTY);
-		} else if (isInCrew == null) {
-
-			throw new BoardExceptionHandler(CREATE_COMMENT_IS_IN_CREW_EMPTY);
 		}
 
 		// 게시글이 존재하지 않을 경우 예외 처리
@@ -75,7 +70,7 @@ public class BoardInteractionServiceImpl implements BoardInteractionService {
 			.board(board)
 			.writerUuid(uuid)
 			.content(commentUploadRequestDto.getContent())
-			.isInCrew(commentUploadRequestDto.getIsInCrew())
+			.isInCrew(false)
 			.build();
 
 		commentRepository.save(comment);
@@ -86,7 +81,7 @@ public class BoardInteractionServiceImpl implements BoardInteractionService {
 			.commentId(comment.getId())
 			.writerUuid(uuid)
 			.content(commentUploadRequestDto.getContent())
-			.isInCrew(commentUploadRequestDto.getIsInCrew())
+			.isInCrew(false)
 			.createdAt(comment.getCreatedAt())
 			.build();
 

--- a/src/main/java/hobbiedo/board/dto/request/CommentUploadRequestDto.java
+++ b/src/main/java/hobbiedo/board/dto/request/CommentUploadRequestDto.java
@@ -13,7 +13,6 @@ import lombok.NoArgsConstructor;
 public class CommentUploadRequestDto {
 
 	private String content;
-	private Boolean isInCrew;
 
 	// Vo 객체를 Dto 객체로 변환
 	public static CommentUploadRequestDto commentUploadVoToDto(
@@ -21,7 +20,6 @@ public class CommentUploadRequestDto {
 
 		return CommentUploadRequestDto.builder()
 			.content(commentUploadRequestVo.getContent())
-			.isInCrew(commentUploadRequestVo.getIsInCrew())
 			.build();
 	}
 }

--- a/src/main/java/hobbiedo/board/vo/request/CommentUploadRequestVo.java
+++ b/src/main/java/hobbiedo/board/vo/request/CommentUploadRequestVo.java
@@ -10,11 +10,8 @@ import lombok.NoArgsConstructor;
 public class CommentUploadRequestVo {
 
 	private String content;
-	// 소모임 소속 여부
-	private Boolean isInCrew;
 
-	public CommentUploadRequestVo(String content, Boolean isInCrew) {
+	public CommentUploadRequestVo(String content) {
 		this.content = content;
-		this.isInCrew = isInCrew;
 	}
 }


### PR DESCRIPTION
## 📣 게시글 댓글 작성 형식 및 저장 로직 수정
### 📅  날짜 - 2024.06.24

### 🌵Branch
feature/modify-comment-format-save-logic  → develop

### 📢 Description
**읽기 전용 서버에서 자체적으로 해당 댓글 작성자의 소모임 소속 여부를 알아내는 로직을 추가함으로써 PostMapping 댓글 작성 데이터 vo 형식 수정**

### 💬Issue Number
[#20 ] - ♻️[REFACTOR] 게시글 댓글 작성 형식 및 저장 로직 수정 #20

### 🛠️Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
**현재 전체적으로 서비스가 테스트를 진행 중에 있어 기존의 댓글 테이블의 소모임 소속여부가 필요없지만 삭제를 못하고 있어, 추후 리펙토링이 가능하면 진행을 하고, 우선적으로는 false 의 형태로 저장한다**